### PR TITLE
feat(footer): add temporary layout for Footer component

### DIFF
--- a/client/src/components/layout/Footer/Footer.stories.tsx
+++ b/client/src/components/layout/Footer/Footer.stories.tsx
@@ -1,0 +1,17 @@
+// components/layout/Footer.stories.tsx
+import type { Meta, StoryObj } from "@storybook/react";
+import Footer from "./Footer";
+
+const meta: Meta<typeof Footer> = {
+	title: "Layout/Footer",
+	component: Footer,
+	tags: ["autodocs"],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Footer>;
+
+export const Default: Story = {
+	render: () => <Footer />,
+};

--- a/client/src/components/layout/Footer/Footer.tsx
+++ b/client/src/components/layout/Footer/Footer.tsx
@@ -1,0 +1,13 @@
+import Button from "@/components/atoms/Button/Button";
+
+const Footer = () => {
+	return (
+		<footer className="flex justify-around p-4 border border-black">
+			<Button text="HOME" onClick={() => console.log("clicked")} />
+			<Button text="SERCH" onClick={() => console.log("clicked")} />
+			<Button text="SETTING" onClick={() => console.log("clicked")} />
+		</footer>
+	);
+};
+
+export default Footer;


### PR DESCRIPTION
Created a basic Footer component and its Storybook setup.

This Footer is intended to eventually include icon-based buttons, but for now uses temporary text buttons to indicate their purpose.  
These text buttons serve as placeholders for actions like "Home", "Search", and "Settings".
